### PR TITLE
Use the crates.io version of the "log".

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ name = "tests"
 
 [dependencies]
 rustc-serialize = "*"
+log = "*"
 
 [[example]]
 name = "kitchen-sink"


### PR DESCRIPTION
Need the Cargo version of the "log" to avoid the `multiple matching crates for`log`` error.
