### PR TITLE
Update for libsyntax API change.

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -76,7 +76,7 @@ fn parse_json(cx: &ExtCtxt, parser: &mut Parser) -> P<Expr> {
             expr
         },
         &Token::OpenDelim(DelimToken::Paren) => {
-            let expr = parser.parse_expr();
+            let expr = parser.parse_expr_panic();
             quote_expr!(cx, {{
                 use ::rustc_serialize::json::ToJson;
                 ($expr).to_json()


### PR DESCRIPTION
In rust-lang/rust@e7d3ae606ed496144554dae499b69207da3b09c5
`parse_expr()` was renamed to `parse_expr_panic()`. This commit reflects
that change.

Fixes #21.