### PR TITLE
Update parse_expr() calls as per changes in libsyntax.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,11 @@
 #![feature(rustc_private)]
 
 extern crate rustc;
+extern crate rustc_plugin;
 extern crate syntax;
 extern crate rustc_serialize;
 
-use rustc::plugin::Registry;
+use rustc_plugin::Registry;
 
 mod plugin;
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -76,7 +76,7 @@ fn parse_json(cx: &ExtCtxt, parser: &mut Parser) -> P<Expr> {
             expr
         },
         &Token::OpenDelim(DelimToken::Paren) => {
-            let expr = parser.parse_expr_panic();
+            let expr = parser.parse_expr().unwrap();
             quote_expr!(cx, {{
                 use ::rustc_serialize::json::ToJson;
                 ($expr).to_json()


### PR DESCRIPTION
Same story again, the related changes are in
rust-lang/rust@44d8abcc0f372dbc7ad58f312303d2e59612dec9