### PR TITLE
Use `TokenTree` from its new module.

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,6 +1,6 @@
-use syntax::ast::TokenTree;
 use syntax::codemap::Span;
 use syntax::ptr::P;
+use syntax::tokenstream::TokenTree;
 
 use syntax::ast::Expr;
 use syntax::ext::base::{ExtCtxt, MacResult, MacEager};


### PR DESCRIPTION
Relevant libsyntax change:
rust-lang/rust@d59accfb065843d12db9180a4f504664e3d23ef1